### PR TITLE
Fix for 'reactMixin is undefined' error.

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ function mixinClass(reactClass, reactMixin) {
 }
 
 module.exports = (function () {
-  reactMixin = mixinProto;
+  var reactMixin = mixinProto;
 
   reactMixin.onClass = function(reactClass, mixin) {
     mixinClass(reactClass, mixin)


### PR DESCRIPTION
Fix for reactMixin undefined error (added 'var' keyword)