### PR TITLE
Fixes react-mixin when a getter throws while it is being mixed in.

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,31 +58,37 @@ function mixinClass(reactClass, reactMixin) {
   var staticProps = {};
 
   Object.keys(reactMixin).forEach(function(key) {
-    if(typeof reactMixin[key] === 'function') {
-      prototypeMethods[key] = reactMixin[key];
+    var descriptor = Object.getOwnPropertyDescriptor(reactMixin, key);
+    if (descriptor.value !== undefined) {
+      if (typeof descriptor.value === "function") {
+        prototypeMethods[key] = reactMixin[key];
+      }
+      else {
+        staticProps[key] = reactMixin[key];
+      }
     }
     else {
-      staticProps[key] = reactMixin[key];
+      Object.defineProperty(reactClass.prototype, key, descriptor);
     }
   });
 
   mixinProto(reactClass.prototype, prototypeMethods);
 
   var mergePropTypes = function(left, right, key){
-    if (!left) return right;  
-    if (!right) return left;  
+    if (!left) return right;
+    if (!right) return left;
 
     var result = {};
     Object.keys(left).forEach(function(leftKey){
       if (!right[leftKey]) {
         result[leftKey] = left[leftKey];
       }
-    }); 
+    });
 
     Object.keys(right).forEach(function(rightKey){
       if (left[rightKey]) {
         result[rightKey] = function checkBothContextTypes(){
-            return right[rightKey].apply(this, arguments) && left[rightKey].apply(this, arguments); 
+            return right[rightKey].apply(this, arguments) && left[rightKey].apply(this, arguments);
         }
       } else {
         result[rightKey] = right[rightKey];

--- a/test/react-mixin.js
+++ b/test/react-mixin.js
@@ -72,6 +72,19 @@ describe('react-mixin', function(){
             expect(reactClass.prototype.contextTypes).not.to.exist;
         });
 
+        it('can mixin a getter that will throw', function() {
+          var obj = {};
+          var desc = {
+            set: undefined,
+            get: function () { throw new Error('invalid context'); },
+            enumerable: true,
+            configurable: false
+          };
+          Object.defineProperty(obj, 'test', desc);
+          reactMixin.onClass(reactClass, obj);
+          expect(Object.getOwnPropertyDescriptor(reactClass.prototype, 'test')).to.eql(desc);
+        })
+
         it('calls getDefaultProps and sets result as static prop', function () {
             var mixin = {
                 getDefaultProps: function() {
@@ -137,7 +150,7 @@ describe('react-mixin', function(){
                 reactMixin.onClass(reactClass, mixin);
                 expect(reactClass.prototype.componentWillMount).to.exist;
 
-                var instance = new reactClass(); 
+                var instance = new reactClass();
                 expect(instance.state).to.eql({foo: 'bar'});
                 instance.componentWillMount();
 


### PR DESCRIPTION
So this may seem failure, but I'm not submitting this PR for the same reason as before.

I'm getting uncaught exceptions from using react-mixin with a a getter that will throw if used without the right context.

Here is an example mixin.
```
let mixin = {
  get value() { return this.state.value; }
};
```

This is where it will throw an uncaught exception, because the mixin has no `state` property.
```
if(typeof reactMixin[key] === 'function') {
// ...
}
```

I'm not sure if this is the best approach, but I had this code left over from when I submitted it before. It works fine given the situation.

I updated the test to better reflect the bug.