### PR TITLE
Return decorated class in mixinClass

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,6 +98,8 @@ function mixinClass(reactClass, reactMixin) {
     propTypes: mixin.MANY_MERGED_LOOSE,
     defaultProps: mixin.MANY_MERGED_LOOSE
   })(reactClass, staticProps);
+  
+  return reactClass;
 }
 
 module.exports = (function () {


### PR DESCRIPTION
Sorry, I forgot to add return statement in mixinClass function. This should work now.