### PR TITLE
Avoid mutating decorated classes

### DIFF
--- a/index.js
+++ b/index.js
@@ -144,7 +144,13 @@ module.exports = (function() {
 
   reactMixin.decorate = function(mixin) {
     return function(reactClass) {
-      return reactMixin.onClass(reactClass, mixin);
+      // Clone the incoming class
+      var newClass = function(props) {
+        reactClass.apply(this, props);
+      };
+      assign(newClass, reactClass);
+      newClass.prototype = Object.create(reactClass.prototype)
+      return reactMixin.onClass(newClass, mixin);
     };
   };
 

--- a/index.js
+++ b/index.js
@@ -146,10 +146,17 @@ module.exports = (function() {
     return function(reactClass) {
       // Clone the incoming class
       var newClass = function(props) {
-        reactClass.apply(this, props);
+        reactClass.apply(this, arguments);
       };
       assign(newClass, reactClass);
-      newClass.prototype = Object.create(reactClass.prototype)
+      newClass.prototype = Object.create(reactClass.prototype, {
+          constructor: {
+              value: newClass,
+              enumerable: false,
+              writable: true,
+              configurable: true
+          }
+      });
       return reactMixin.onClass(newClass, mixin);
     };
   };

--- a/index.js
+++ b/index.js
@@ -138,7 +138,8 @@ module.exports = (function() {
   var reactMixin = mixinProto;
 
   reactMixin.onClass = function(reactClass, mixin) {
-    return mixinClass(reactClass, mixin);
+    mixinClone = assign({}, mixin);
+    return mixinClass(reactClass, mixinClone);
   };
 
   reactMixin.decorate = function(mixin) {

--- a/test/react-mixin.js
+++ b/test/react-mixin.js
@@ -157,6 +157,18 @@ describe('react-mixin', function() {
         expect(reactClass.contextTypes).not.to.be.ok();
         expect(reactClass.prototype.getChildContext).not.to.be.ok();
       });
+
+      it("should correctly identify constructor", function () {
+        var mixin = {
+          contextTypes: {},
+          getChildContext: function() {}
+        };
+
+        var NewComponent = reactMixin.decorate(mixin)(reactClass);
+        var instance = new NewComponent();
+        expect(instance.constructor).not.to.be(reactClass);
+        expect(instance.constructor).to.be(NewComponent);
+      });
     });
 
     it('handles contextTypes', function() {

--- a/test/react-mixin.js
+++ b/test/react-mixin.js
@@ -111,22 +111,52 @@ describe('react-mixin', function() {
       expect(reactClass.prototype.getDefaultProps).not.to.exist;
     });
 
-    it('acts as decorator', function() {
-      var mixin = {
-        getDefaultProps: function() {
-          return {
-            test: 'test'
+    describe("decorator", function () {
+      it('acts as decorator', function() {
+        var mixin = {
+          getDefaultProps: function() {
+            return {
+              test: 'test'
+            }
           }
-        }
-      };
+        };
 
-      var decorator = reactMixin.decorate(mixin);
-      var instance = decorator(reactClass);
+        var decorator = reactMixin.decorate(mixin);
+        var instance = decorator(reactClass);
 
-      expect(reactClass.defaultProps).to.eql({
-        test: 'test'
+        expect(instance.defaultProps).to.eql({
+          test: 'test'
+        });
+        expect(instance.prototype.getDefaultProps).not.to.exist;
       });
-      expect(reactClass.prototype.getDefaultProps).not.to.exist;
+
+      it('mixins proto and static props separately', function() {
+        var mixin = {
+          contextTypes: {},
+          getChildContext: function() {}
+        };
+
+        var NewComponent = reactMixin.decorate(mixin)(reactClass);
+
+        expect(NewComponent.contextTypes).to.exist;
+        expect(NewComponent.prototype.getChildContext).to.exist;
+
+        expect(NewComponent.getChildContext).not.to.exist;
+        expect(NewComponent.prototype.contextTypes).not.to.exist;
+      });
+
+      it('should return a copy of the class', function () {
+        var mixin = {
+          contextTypes: {},
+          getChildContext: function() {}
+        };
+
+        var NewComponent = reactMixin.decorate(mixin)(reactClass);
+        expect(NewComponent).not.to.be(reactClass);
+        expect(NewComponent.prototype).not.to.be(reactClass.prototype);
+        expect(reactClass.contextTypes).not.to.be.ok();
+        expect(reactClass.prototype.getChildContext).not.to.be.ok();
+      });
     });
 
     it('handles contextTypes', function() {
@@ -396,5 +426,4 @@ describe('react-mixin', function() {
           expect(obj.spec).to.equal(4);
         });
       });
-
     });

--- a/test/react-mixin.js
+++ b/test/react-mixin.js
@@ -268,6 +268,26 @@ describe('react-mixin', function() {
 
             expect(obj.state.counter).to.be.eql(23);
           });
+
+          it('should not mutate mixin definition', function () {
+            var mixin = {
+              getInitialState: function() {
+                return {
+                  counter: 22
+                }
+              },
+              getDefaultProps: function () {
+                return {
+                  step: 1
+                }
+              }
+            };
+
+            reactMixin.onClass(reactClass, mixin);
+
+            expect(mixin.getInitialState).to.be.a('function');
+            expect(mixin.getDefaultProps).to.be.a('function');
+          });
         });
       });
 


### PR DESCRIPTION
Currently, `@reactMixin.decorate` will mutate the decorated class, which causes tools like [react-transform](https://github.com/gaearon/react-transform-boilerplate) to break. Specifically, it will try to apply the mixin _twice_, which could throw collision errors, for example, if the mixin applies a `childContextTypes` property.

This change effectively subclasses the component and applies the mixin to the subclass instead, returning the subclass. (it's a pure function now, I believe) In any case, it now works much better with react-transform and react-proxy (it still doesn't work perfectly, but much better, see this issue: https://github.com/gaearon/react-proxy/issues/24)

The behavior of `onClass` remains mostly the same (although see below), mutating the class passed to it.

Potential caveats:
* Could cause marginal performance degradation
* It's technically a breaking change; if you're using the decorator syntax, it will continue to work, but if, for some reason, you're calling it instead of `onClass` or are depending on the mutation to take place, your code will no longer function.

While I was in the code worrying about mutations, I also noticed that if the mixin implemented `getInitialState` or `getDefaultProps`, the _original mixin_ would be modified and the function would be replaced with `componentWillMount` or a `defaultProps` static property, respectively. Among other things, this could cause problems if you're combining `createClass` and ES6 syntax, causing mixins to non-deterministically stop working in a `createClass` component if an ES6 component was loaded first. That way lies madness, so I did a quick shallow copy of the mixin before applying it in `onClass`.

Potential caveats:
* Marginally increases the memory footprint if a mixin is used more than once; could be worked around with a memoized "prepareMixinForES6" type function though.

Let me know if there are any issues here!