### PR TITLE
Fix non-enumerable static properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -153,7 +153,9 @@ module.exports = (function() {
       for (var key in reactClass) {
         // Ordinarily, you'd use reactClass.hasOwnProperty(key) here
         // But we want to catch ALL static properties
-        statics[key] = reactClass[key];
+        if (!Function.prototype[key]) {
+          statics[key] = reactClass[key];
+        }
       }
       assign(newClass, statics);
       newClass.prototype = Object.create(reactClass.prototype, {

--- a/index.js
+++ b/index.js
@@ -148,7 +148,14 @@ module.exports = (function() {
       var newClass = function(props) {
         reactClass.apply(this, arguments);
       };
-      assign(newClass, reactClass);
+      // Collect static properties
+      var statics = {};
+      for (var key in reactClass) {
+        // Ordinarily, you'd use reactClass.hasOwnProperty(key) here
+        // But we want to catch ALL static properties
+        statics[key] = reactClass[key];
+      }
+      assign(newClass, statics);
       newClass.prototype = Object.create(reactClass.prototype, {
           constructor: {
               value: newClass,

--- a/test/react-mixin.js
+++ b/test/react-mixin.js
@@ -169,6 +169,27 @@ describe('react-mixin', function() {
         expect(instance.constructor).not.to.be(reactClass);
         expect(instance.constructor).to.be(NewComponent);
       });
+
+      it('merges contextTypes even if class is proxied', function () {
+        reactClass.contextTypes = {
+          existingContext: React.PropTypes.any
+        };
+
+        var mixin = {
+          contextTypes: {
+            mixinContext: React.PropTypes.any
+          }
+        };
+
+        // Emulate what react-proxy does to a class
+        // https://github.com/gaearon/react-proxy/blob/master/src/createClassProxy.js
+        var proxiedClass = function Proxied() {};
+        proxiedClass.prototype.constructor = proxiedClass;
+        proxiedClass.prototype.constructor.__proto__ = reactClass;
+
+        var NewComponent = reactMixin.decorate(mixin)(proxiedClass);
+        expect (NewComponent.contextTypes).to.have.keys('existingContext', 'mixinContext');
+      });
     });
 
     it('handles contextTypes', function() {


### PR DESCRIPTION
It's me again! Just tested 2.0.1 in a real-world `react-transform` project and it turns out that it's actually completely replacing `contextTypes` with the ones from the mixin. This seems to be because react-proxy makes static properties non-enumerable (it's pretty crazy), so the only way to get at them is an unprotected (that is, no `hasOwnProperty` check) `for..of` loop. 

I couldn't think of any cases where that would cause unintended effects - constructors don't usually have any inherited properties, and when they do (like in the case of react-proxy), they're usually meant to be treated just like any other static property.

(Edit: after thinking about it, I decided to protect the loop with a `Function.prototype[key]` check to make sure we don't get any custom utility methods or polyfills or things like that.)