### PR TITLE
Add method 'mixin' as decorator for many mixins

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,30 @@ This is a very thin wrapper.
   }
 ```
 
+## And more
+
+Method `mixin` is a decorator for many mixins. It will be save `displayName` for your component.
+
+```js
+// Real world example
+
+import React, { Component } from 'react';
+import { mixin as Mixin } from 'react-mixin';
+import { Navigate } from 'react-router';
+import { LogMixins } from 'private-logger';
+
+@Mixin(Navigate, LogMixins)
+export default class SearchComponent extends Component {
+  onChange() {
+    this.say('Start search:', this.state.query); // Method from private-logger.LogMixins
+    this.transitionTo('search', { query: this.state.query }); // Method from react-router.Navigate
+  }
+  render() {
+    // return component code
+  }
+}
+```
+
 ## Differences from createClass
 
 @ndout resolved the differences by adding `reactMixin.onClass`.  If there are any more incompatibilites, **other than autobinding methods which is intentionally omitted**, please create an issue.

--- a/index.js
+++ b/index.js
@@ -169,6 +169,16 @@ module.exports = (function() {
       return reactMixin.onClass(newClass, mixin);
     };
   };
+  
+  reactMixin.mixin = function() {
+    return function (Component) {
+      var mixins = Array.prototype.slice.call(arguments);
+      for (var mi = 0, mlen = mixins.length; mi < mlen; mi++) {
+        Component = reactMixin.onClass(Component, mixins[mi]);
+      }
+      return Component;
+    }
+  }
 
   return reactMixin;
 })();


### PR DESCRIPTION
I can't save displayName and applyMany mixins in base version.

I suggest method `mixin`:

```js
  reactMixin.mixin = function() {
    return function (Component) {
      var mixins = Array.prototype.slice.call(arguments);
      for (var mi = 0, mlen = mixins.length; mi < mlen; mi++) {
        Component = reactMixin.onClass(Component, mixins[mi]);
      }
      return Component;
    }
  }
```

Usage:

```js
var reactMixin = require('react-mixin');
var Mixin = reactMixin.mixin;
var mxi = require('mixins');

@Mixin(mxi.route)
class Component {
  method() {
    this.routeTo('path'); // method from `mixins.route`
  }
}
```